### PR TITLE
Re-fix multine AND quotes in commit message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Parse Commit Message
-      shell: bash
-      run: |
-        echo "NEW_MESSAGE=${{ toJSON(github.event.head_commit.message) }}" | cut -f 1 -d$'\n' >> $GITHUB_ENV
     - name: Microsoft Teams Notification
       uses: skitionek/notify-microsoft-teams@master
       with:
@@ -24,7 +20,7 @@ runs:
             "title": "The ${{ github.action }} workflow on ${{github.repository}}/@${{ github.ref_name }} was ${{ (job.status == 'cancelled' && '') || 'a' }} ${{job.status}}",
             "sections": [
               {
-                "activityTitle": "${{ env.NEW_MESSAGE }}",
+                "activityTitle": ${{ toJSON(github.event.head_commit.message) }},
                 "activitySubtitle": "${{ github.event.head_commit.timestamp}}",
                 "activityImage": "${{ (job.status == 'success' && 'https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/success.png') || 'https://raw.githubusercontent.com/Skitionek/notify-microsoft-teams/master/icons/failure.png' }}",
                 "facts": [


### PR DESCRIPTION
The combination of my solution with William's broke. The `toJSON` GHA function adds quote marks to strings, so this line crashes:
```
echo "NEW_MESSAGE=${{ toJSON(github.event.head_commit.message) }}" | cut -f 1 -d$'\n' >> $GITHUB_ENV
```

The `toJSON` function correctly handles multiline messages as-is, so there's no need for the bash command anyhow.