### PR TITLE
Fix quotes in commit messages again, and handle multiline better

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Parse Commit Message
       shell: bash
       run: |
-        echo "NEW_MESSAGE=${{ github.event.head_commit.message }}" | cut -f 1 -d$'\n' >> $GITHUB_ENV
+        echo NEW_MESSAGE=${{ toJSON(github.event.head_commit.message) }} | awk -F'\\\\[rn]' '{print $1}' >> $GITHUB_ENV
     - name: Microsoft Teams Notification
       uses: skitionek/notify-microsoft-teams@master
       with:


### PR DESCRIPTION
Okay, *really* fixed everything this time. (Turns out the previous version was breaking on quote marks again)

I tested with and without quote marks, single-line commits, multiline commits with "\n", and multiline with "\r\n"